### PR TITLE
修复消息API文档中参数说明的一些问题

### DIFF
--- a/docs/develop/pythonsdk/api/message/post_message.md
+++ b/docs/develop/pythonsdk/api/message/post_message.md
@@ -39,7 +39,7 @@ client.run(appid={appid}, token={token})
 | ark     | 否   | [MessageArk](#messageark)     | ark 消息                                                                                 |
 | image   | 否   | string                        | 图片 url 地址                                                                            |
 | msg_id  | 否   | string                        | 要回复的消息 id。**带了 msg_id 视为[被动回复消息](#被动回复消息)，否则视为主动推送消息** |
-| message_reference | [MessageReference](#messagereference) | 否  | 引用消息对象  |
+| message_reference | 否 | [MessageReference](#messagereference)  | 引用消息对象  |
 
 `content`、`embed`、`ark`、`image`**至少需要有一个字段**，否则无法下发消息。
 


### PR DESCRIPTION
参数说明中`message_reference`的必填和类型写反了。